### PR TITLE
Replace Ritter's bounding sphere with Welzl's algorithm

### DIFF
--- a/bmesh_operations/mesh_split_by_island.py
+++ b/bmesh_operations/mesh_split_by_island.py
@@ -16,7 +16,15 @@ def get_linked_faces(f):
     list of bmesh.types.BMFace: A list of all faces linked to the starting face.
     """
 
+    old_limit = sys.getrecursionlimit()
     sys.setrecursionlimit(10 ** 6)
+    try:
+        return _get_linked_faces(f)
+    finally:
+        sys.setrecursionlimit(old_limit)
+
+
+def _get_linked_faces(f):
     if f.tag:
         # If the face is already tagged, return empty list
         return []
@@ -35,7 +43,7 @@ def get_linked_faces(f):
         if not len(faces) == 0:
             for elem in faces:
                 # Extend the list with second-degree connected faces
-                f_linked.extend(get_linked_faces(elem))
+                f_linked.extend(_get_linked_faces(elem))
 
     return f_linked
 


### PR DESCRIPTION
## Summary
  - Add unit tests for `calculate_bounding_sphere()` covering 14 geometric cases: single point, two points, collinear/non-collinear triples, coplanar/non-coplanar quadruples, cubes, and icospheres
  - Replace the AABB-seeded Ritter expansion with Welzl's algorithm to compute the exact minimum enclosing sphere
  - Fix an incorrect midpoint update formula and order-dependent center bias in the previous implementation

  ## Context
  The [Sphere Collider documentation](https://weisl.github.io/collider_shapes/#sphere-collider) notes a known limitation: "The sphere generation uses a fast algorithm that does not always provide the optimal result. This happens especially for simple box meshes." This PR addresses that limitation by replacing the Ritter-style approximation with Welzl's algorithm, which computes the provably smallest enclosing sphere in expected O(n) time.

  The previous implementation's center was biased toward the axis-aligned extremes, and the expansion pass had a bug in the midpoint update that could further skew results.

  The tests assert optimal (minimum enclosing sphere) center and radius values for each geometry. To verify the improvement:

  1. Check out the test commit alone (`8bada84`) against the old Ritter implementation and run:
     `blender --background --python tests/test_bounding_sphere.py`
  Six of 14 tests fail (right triangles, equilateral triangles, asymmetric tetrahedra, and cubes produce oversized or off-center spheres).

  2. Check out the Welzl commit (`2fcb0ce`) and run the same command — all 14 tests pass.

  ## Test plan
  - [ ] Run `blender --background --python tests/test_bounding_sphere.py` — all 14 tests pass
  - [ ] Verify sphere colliders look correct in Blender on a variety of meshes (cubes, elongated boxes, asymmetric shapes)
  - [ ] Confirm no regression in sphere generation for edit-mode and loose-mesh workflows