### PR TITLE
Fix tooltips for visibility and material operators

### DIFF
--- a/collider_operators/__init__.py
+++ b/collider_operators/__init__.py
@@ -11,6 +11,7 @@ classes = (
     visibility_selection_deletion.COLLISION_OT_complex_delete,
     visibility_selection_deletion.COLLISION_OT_simple_complex_select,
     visibility_selection_deletion.COLLISION_OT_simple_complex_delete,
+    visibility_selection_deletion.COLLISION_OT_toggle_group_visibility,
     visibility_selection_deletion.COLLISION_OT_all_select,
     visibility_selection_deletion.COLLISION_OT_all_delete,
     visibility_selection_deletion.COLLISION_OT_non_collider_select,

--- a/collider_operators/visibility_selection_deletion.py
+++ b/collider_operators/visibility_selection_deletion.py
@@ -2,6 +2,8 @@ import bpy
 
 from ..groups.user_groups import default_groups_enum
 
+_group_desc = {entry[0]: entry[2] for entry in default_groups_enum}
+
 
 class COLLISION_OT_Selection(bpy.types.Operator):
     """Select collider objects"""
@@ -89,10 +91,43 @@ class COLLISION_OT_simple_complex_select(COLLISION_OT_Selection):
     bl_description = 'Select all objects that are defined as simple and complex colliders'
 
 
+class COLLISION_OT_toggle_group_visibility(bpy.types.Operator):
+    bl_idname = "object.toggle_collider_group_visibility"
+    bl_label = "Toggle Group Visibility"
+    bl_options = {"REGISTER", "UNDO"}
+
+    mode: bpy.props.EnumProperty(items=default_groups_enum, default='ALL_COLLIDER')
+
+    @classmethod
+    def description(cls, context, properties):
+        return _group_desc.get(properties.mode, '')
+
+    def execute(self, context):
+        colSettings = context.scene.simple_collider
+        group_map = {
+            'ALL_COLLIDER': colSettings.visibility_toggle_all,
+            'OBJECTS':      colSettings.visibility_toggle_obj,
+            'USER_01':      colSettings.visibility_toggle_user_group_01,
+            'USER_02':      colSettings.visibility_toggle_user_group_02,
+            'USER_03':      colSettings.visibility_toggle_user_group_03,
+        }
+        prop = group_map.get(self.mode)
+        if prop is not None:
+            prop.hide = not prop.hide
+        return {'FINISHED'}
+
+
 class COLLISION_OT_all_select(COLLISION_OT_Selection):
     bl_idname = "object.all_select_collisions"
-    bl_label = "Select all Colliders"
+    bl_label = "Select All"
     bl_description = 'Select all collider objects: Simple, Complex, Simple and Complex.'
+
+    @classmethod
+    def description(cls, context, properties):
+        if properties.mode == 'ALL_COLLIDER':
+            return cls.bl_description
+        desc = _group_desc.get(properties.mode, '')
+        return desc.replace('Show/Hide', 'Select') if desc else cls.bl_description
 
 
 class COLLISION_OT_non_collider_select(COLLISION_OT_Selection):

--- a/pyshics_materials/physics_materials.py
+++ b/pyshics_materials/physics_materials.py
@@ -105,9 +105,10 @@ class MATERIAL_OT_physics_material_create(bpy.types.Operator):
 
 
 class MATERIAL_OT_set_physics_material(bpy.types.Operator):
-    """Tooltip"""
+    """Assign this Physics Material to selected objects"""
     bl_idname = "material.set_physics_material"
     bl_label = "Set Physics Material"
+    bl_description = "Assign this Physics Material to selected objects"
     bl_options = {'REGISTER', 'UNDO'}
 
     physics_material_name: StringProperty()

--- a/ui/properties_panels.py
+++ b/ui/properties_panels.py
@@ -150,10 +150,10 @@ def draw_group_properties(context, property, col_01, col_02, mode, user_group=Fa
 
     row = col_02.row(align=True)
 
-    if property.hide:
-        row.prop(property, 'hide', text=str(property.hide_text), icon=str(property.hide_icon))
-    else:
-        row.prop(property, 'hide', text=str(property.show_text), icon=str(property.show_icon))
+    icon = str(property.hide_icon) if property.hide else str(property.show_icon)
+    text = str(property.hide_text) if property.hide else str(property.show_text)
+    op = row.operator("object.toggle_collider_group_visibility", text=text, icon=icon, depress=property.hide)
+    op.mode = group_identifier
 
     op = row.operator("object.all_select_collisions", icon=str(property.selected_icon),
                       text=str(property.selected_text))


### PR DESCRIPTION
Fix a bug where all visibility/select toggles had the same tooltips:
- Blender only supports dynamic tooltips on operators (via `description()` classmethod), not on prop buttons, so this change converts group visibility toggles from `row.prop()` to `row.operator()` so each group's label can appear in the tooltip at draw time
- Introduce `COLLISION_OT_toggle_group_visibility` to perform the hide toggle that was previously handled implicitly by the prop button, since switching to an operator requires explicit `execute()` logic
- Extend `COLLISION_OT_all_select` with `description()` so the select button gets the same group-aware tooltip as the visibility button beside it

Also Fix `MATERIAL_OT_set_physics_material tooltip` (was placeholder "Tooltip").