### PR TITLE
Fix: Disable convert operators when selecting non-viable objects

### DIFF
--- a/collider_conversion/convert_to_collider.py
+++ b/collider_conversion/convert_to_collider.py
@@ -23,7 +23,18 @@ class OBJECT_OT_convert_to_collider(OBJECT_OT_add_bounding_object, Operator):
     @classmethod
     def poll(cls, context):
         # Convert is only supported in object mode
-        return False if context.mode != 'OBJECT' else super().poll(context)
+        if context.mode != 'OBJECT':
+            return False
+        
+        # Check if there's at least one valid object that is not already a collider
+        for obj in context.selected_objects:
+            if obj.type in {'MESH', 'CURVE', 'SURFACE', 'FONT', 'META'}:
+                # If the object is not a collider, it's viable for conversion
+                if not obj.get('isCollider'):
+                    return super().poll(context)
+        
+        # All selected valid objects are already colliders
+        return False
 
     def cancel_cleanup(self, context, **kwargs):
         print('base_objs = ' + str(self.base_objs))

--- a/collider_conversion/convert_to_empty.py
+++ b/collider_conversion/convert_to_empty.py
@@ -27,16 +27,12 @@ class OBJECT_OT_convert_to_empty(Operator):
 
     @classmethod
     def poll(cls, context):
-        count = 0
         if context.mode != 'OBJECT':
             return False
         for obj in context.selected_objects:
             if obj.get('isCollider') and obj.get('collider_shape') in SUPPORTED_SHAPES:
                 return True
-        for obj in context.selected_objects:
-            if obj.type == 'MESH':
-                count = count + 1
-        return count > 0
+        return False
 
     def execute(self, context):
         t0 = time.time()

--- a/collider_conversion/convert_to_mesh.py
+++ b/collider_conversion/convert_to_mesh.py
@@ -39,14 +39,13 @@ class OBJECT_OT_convert_to_mesh(Operator):
 
     @classmethod
     def poll(cls, context):
-        count = 0
         if context.mode != 'OBJECT':
             return False
 
         for obj in context.selected_objects:
-            if obj.type in VALID_OBJECT_TYPES:
-                count = count + 1
-        return count > 0
+            if obj.type in VALID_OBJECT_TYPES and obj.get('isCollider'):
+                return True
+        return False
 
     def execute(self, context):
         colSettings = context.scene.simple_collider


### PR DESCRIPTION
## Summary
- Implemented issue #636: Convert operators now check if selected objects are viable for conversion
- Updated poll methods for convert_to_mesh, convert_to_empty, and convert_to_collider operators
- convert_to_mesh: Only enabled when selecting collider objects (isCollider=True)
- convert_to_empty: Only enabled when selecting collider objects with supported shapes
- convert_to_collider: Only enabled when selecting at least one non-collider object

## Verification
- All modified files compile successfully
- Logic verified: operators are enabled/disabled based on selection viability

Closes #636
